### PR TITLE
Migrate from master-slave phrasing

### DIFF
--- a/zpr/database/gff.py
+++ b/zpr/database/gff.py
@@ -5,7 +5,7 @@ import re
 
 
 class Gff(FormatInterface):
-    GffRecord = namedtuple('GffRecord', ['seq_id', 'start', 'length', 'order', 'master_seq_id'])
+    GffRecord = namedtuple('GffRecord', ['seq_id', 'start', 'length', 'order', 'main_seq_id'])
 
     def import_records_from_file_to_db(self, filename):
         for record in self._gen_record_from_file(filename):

--- a/zpr/urls.py
+++ b/zpr/urls.py
@@ -24,7 +24,7 @@ base_chromosomes_routes.register(r'annotation_types', AnnotationTypeSeqSectionVi
 
 router.register(r'annotations', PaginatedAnnotationViewSet)\
       .register(r'aggregations', PaginatedAnnotationAggregationViewSet, base_name='chromosome-annotation_types-seqsection',
-                                                    parents_query_lookups=['aggregated_by__annotation_master'])
+                                                    parents_query_lookups=['aggregated_by__annotation_main'])
 
 
 ###### posrednie api od organizmu ######
@@ -36,12 +36,12 @@ chromosome_routes = router.register(r'organisms', OrganismViewSet, base_name='or
 chromosome_routes.register(r'annotations', AnnotationViewSet, base_name='organism-chromosome-annotations',
                                                parents_query_lookups=['chromosome__organism', 'chromosome'])\
                  .register(r'aggregations', AnnotationAggregationViewSet, base_name='organism-chromosome-annotation-aggreations',
-                                                    parents_query_lookups=['chromosome__organism', 'chromosome', 'aggregated_by__annotation_master'])
+                                                    parents_query_lookups=['chromosome__organism', 'chromosome', 'aggregated_by__annotation_main'])
 
 chromosome_routes.register(r'paginated_annotations', PaginatedAnnotationViewSet, base_name='organism-chromosome-paginated_annotations',
                                                parents_query_lookups=['chromosome__organism', 'chromosome'])\
                  .register(r'aggregations', PaginatedAnnotationAggregationViewSet, base_name='organism-chromosome-paginated_annotations-paginated_aggregations',
-                                                    parents_query_lookups=['chromosome__organism', 'chromosome', 'aggregated_by__annotation_master'])
+                                                    parents_query_lookups=['chromosome__organism', 'chromosome', 'aggregated_by__annotation_main'])
 
 chromosome_routes.register(r'annotation_types', AnnotationTypeSeqSectionViewSet, base_name='organism-chromosome-annotation_types',
                                                parents_query_lookups=['annotations__chromosome__organism', 'annotations__chromosome'])\

--- a/zprapp/dataloader/gff.py
+++ b/zprapp/dataloader/gff.py
@@ -10,7 +10,7 @@ class Gff(FormatInterface):
                                          'type_name', 'type_short_name',
                                          'annotation_start_chr', 'annotation_length',
                                          'annotation_name', 'annotation_id',
-                                         'annotation_master', 'start_on_master'])
+                                         'annotation_main', 'start_on_main'])
 
     def __init__(self, org):
         self.org = org
@@ -43,7 +43,7 @@ class Gff(FormatInterface):
 
     def export_records_from_db_to_stream(self):
         stream = io.StringIO()
-        stream.write(unicode("# org_name\tchr_number\tchr_length\tchr_ordered\ttype_name\ttype_short_name\tannotation_start_chr\tannotation_length\tannotation_name\tannotation_id\tannotation_master\tstart_on_master\n"))
+        stream.write(unicode("# org_name\tchr_number\tchr_length\tchr_ordered\ttype_name\ttype_short_name\tannotation_start_chr\tannotation_length\tannotation_name\tannotation_id\tannotation_main\tstart_on_main\n"))
         for record in self._gen_record_from_db():
             for r in record:
                 stream.write(unicode(r))
@@ -60,15 +60,15 @@ class Gff(FormatInterface):
             for a in annotations.iterator():
                 try:
                     aggregation = a.aggregated_by
-                    master = aggregation.annotation_master.id
-                    start_on_master = aggregation.start_local
+                    main = aggregation.annotation_main.id
+                    start_on_main = aggregation.start_local
                 except:
-                    master = None
-                    start_on_master = None
+                    main = None
+                    start_on_main = None
                 yield self.GffRecord(self.org.name,
                                      chromosome.number, chromosome.length, chromosome.ordered,
                                      a.type.name, a.type.short_name,
                                      a.start_chr, a.length,
                                      a.name, a.id,
-                                     master, start_on_master)
+                                     main, start_on_main)
                 # yield self.GffRecord(s.id, int(scfld.start), int(scfld.length), scfld.order, scfld.chromosome_id)

--- a/zprapp/migrations/0001_initial.py
+++ b/zprapp/migrations/0001_initial.py
@@ -72,12 +72,12 @@ class Migration(migrations.Migration):
         ),
         migrations.AddField(
             model_name='aggregation',
-            name='annotation_master',
-            field=models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name='aggregation_slaves', to='zprapp.Annotation'),
+            name='annotation_main',
+            field=models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name='aggregation_subordinates', to='zprapp.Annotation'),
         ),
         migrations.AddField(
             model_name='aggregation',
-            name='annotation_slave',
+            name='annotation_subordinate',
             field=models.OneToOneField(on_delete=django.db.models.deletion.CASCADE, related_name='aggregated_by', to='zprapp.Annotation'),
         ),
     ]

--- a/zprapp/models.py
+++ b/zprapp/models.py
@@ -20,7 +20,7 @@ class Chromosome(models.Model):
 class AnnotationType(models.Model):
     name = models.TextField(unique=True)
     short_name = models.TextField(null=True)
-    # type_master = models.ForeignKey("AnnotationType", related_name='type_slaves', null=True)
+    # type_main = models.ForeignKey("AnnotationType", related_name='type_subordinates', null=True)
 
     def __unicode__(self):
         return self.name
@@ -38,5 +38,5 @@ class Annotation(models.Model):
 
 class Aggregation(models.Model):
     start_local = models.IntegerField(null=True)
-    annotation_slave = models.OneToOneField(Annotation, related_name='aggregated_by')
-    annotation_master = models.ForeignKey(Annotation, related_name='aggregation_slaves')
+    annotation_subordinate = models.OneToOneField(Annotation, related_name='aggregated_by')
+    annotation_main = models.ForeignKey(Annotation, related_name='aggregation_subordinates')

--- a/zprapp/serializers.py
+++ b/zprapp/serializers.py
@@ -51,12 +51,12 @@ class ChromosomeAnnotationSerializer(serializers.ModelSerializer):
 class AnnotationSerializer(serializers.ModelSerializer):
     # type = AnnotationTypeSerializer()
     type = serializers.ReadOnlyField(source='type.name')
-    annotation_master = serializers.ReadOnlyField(source='aggregated_by.annotation_master.id')
+    annotation_main = serializers.ReadOnlyField(source='aggregated_by.annotation_main.id')
 
     class Meta:
         model = Annotation
         fields = ("start_chr", "length", "name",
-                  "chromosome", "id", "type", "annotation_master")
+                  "chromosome", "id", "type", "annotation_main")
 
 
 class AnnotationDetailSerializer(AnnotationSerializer):
@@ -79,4 +79,4 @@ class AnnotationAggregationDetailSerializer(AnnotationDetailSerializer, Annotati
 class AggregationSerializer(serializers.ModelSerializer):
     class Meta:
         model= Aggregation
-        fields = ("id", "start_local", "annotation_master", "annotation_slave")
+        fields = ("id", "start_local", "annotation_main", "annotation_subordinate")


### PR DESCRIPTION
For diversity reasons, it would be nice to try to avoid 'master' and 'slave' terminology in this repository which can be associated to slavery. The master-slave terminology could be problematic for people in several countries which has the history of slavery like Romania, USA and many others. Thank you for considering the proposal. Let me know if any changes in the PR are needed, I would be happy to implement them.